### PR TITLE
Batch 3: ATH dead-end fallback, cards above toolbar, dedup relativeDate

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3234,6 +3234,34 @@ a.il-name:hover { color: var(--orange); }
   line-height: 1.55;
   font-size: 0.88rem;
 }
+.ath-dead-end {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 24px 0 8px;
+}
+.ath-dead-end-msg {
+  margin: 0;
+  color: var(--text-2);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+.ath-dead-end-link {
+  display: inline-block;
+  color: var(--orange);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 10px 20px;
+  border: 2px solid var(--orange);
+  border-radius: 8px;
+  transition: background 0.15s, color 0.15s;
+}
+.ath-dead-end-link:hover {
+  background: var(--orange);
+  color: #fff;
+}
 [data-theme="light"] .bundle-card-overlay {
   background: linear-gradient(180deg, rgba(255,255,255,0.06) 0%, rgba(43,36,27,0.08) 46%, rgba(43,36,27,0.18) 100%);
 }

--- a/src/pages/around-the-horn/index.astro
+++ b/src/pages/around-the-horn/index.astro
@@ -17,7 +17,9 @@ import Layout from '../../layouts/Layout.astro';
     </div>
   </main>
 
-  <script type="module">
+  <script>
+    import { relativeDate } from '../../scripts/utils.js';
+
     const grid = document.getElementById('athStoryGrid');
     const title = document.getElementById('athPageTitle');
     const subtitle = document.getElementById('athPageSubtitle');
@@ -36,19 +38,6 @@ import Layout from '../../layouts/Layout.astro';
       } catch {
         return '';
       }
-    }
-
-    function relativeDate(dateStr) {
-      const d = new Date(dateStr);
-      if (Number.isNaN(d.getTime())) return '';
-      const diff = Date.now() - d.getTime();
-      const minutes = Math.floor(diff / 60000);
-      if (minutes < 60) return `${Math.max(minutes, 1)}m ago`;
-      const hours = Math.floor(minutes / 60);
-      if (hours < 24) return `${hours}h ago`;
-      const days = Math.floor(hours / 24);
-      if (days < 7) return `${days}d ago`;
-      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     }
 
     function renderStoryCard(article) {
@@ -76,8 +65,11 @@ import Layout from '../../layouts/Layout.astro';
 
     if (!bundle) {
       title.textContent = 'Story bundle unavailable';
-      subtitle.textContent = 'Open an Around the Horn card from the homepage first so this page can load the saved related-coverage bundle.';
-      grid.innerHTML = '<div class="feed-msg">No saved Around the Horn bundle was found for this story yet.</div>';
+      subtitle.textContent = 'This bundle was generated during a previous session and is no longer available.';
+      grid.innerHTML = `<div class="ath-dead-end">
+        <p class="ath-dead-end-msg">This bundle was generated during a previous session and is no longer available.</p>
+        <a class="ath-dead-end-link" href="${import.meta.env.BASE_URL}">← Back to YardReport</a>
+      </div>`;
     } else {
       title.textContent = bundle.label || 'Around the Horn';
       subtitle.textContent = `${bundle.sourceCount || 0} sources • ${(bundle.articles || []).length} related articles`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -101,6 +101,8 @@ import Layout from '../layouts/Layout.astro';
 
     <!-- Feed -->
     <main class="feed-area">
+      <!-- Around the Horn bundle cards — rendered above the toolbar -->
+      <div class="ath-bundle-container" id="athBundleContainer"></div>
       <div class="feed-toolbar">
         <div class="toolbar-left">
           <div class="pill-group" id="categoryFilters">

--- a/src/scripts/feeds.js
+++ b/src/scripts/feeds.js
@@ -725,9 +725,11 @@ function setupThumbObserver() {
 // ── Render articles ───────────────────────────────────────────────
 export function renderArticles() {
   const list = $('articleList');
+  const athContainer = $('athBundleContainer');
   const arts = getFilteredArticles();
 
   if (!arts.length) {
+    if (athContainer) athContainer.innerHTML = '';
     list.innerHTML = '<div class="feed-msg">No articles match your filters.</div>';
     return;
   }
@@ -753,14 +755,19 @@ export function renderArticles() {
     limit: MAX_VISIBLE_ARTICLES,
   });
 
-  if (bundles.length) {
-    html += `<section class="ath-section">
-      <div class="ath-section-head">
-        <span class="ath-section-kicker">Featured Stories</span>
-        <h2 class="ath-section-title">Around the Horn</h2>
-      </div>
-      <div class="ath-bundle-grid">${(() => { const used = new Set(); return bundles.map(b => renderBundle(b, arts, used)).join(''); })()}</div>
-    </section>`;
+  // Render ATH bundle cards into the dedicated container above the toolbar
+  if (athContainer) {
+    if (bundles.length) {
+      athContainer.innerHTML = `<section class="ath-section">
+        <div class="ath-section-head">
+          <span class="ath-section-kicker">Featured Stories</span>
+          <h2 class="ath-section-title">Around the Horn</h2>
+        </div>
+        <div class="ath-bundle-grid">${(() => { const used = new Set(); return bundles.map(b => renderBundle(b, arts, used)).join(''); })()}</div>
+      </section>`;
+    } else {
+      athContainer.innerHTML = '';
+    }
   }
 
   const useGroups = state.sortBy === 'dateGroup' || state.sortBy === 'source';
@@ -787,7 +794,9 @@ export function renderArticles() {
   list.innerHTML = html;
   setupThumbObserver();
 
-  list.querySelectorAll('.ath-card-link').forEach(link => {
+  // Wire up ATH bundle click handlers from the dedicated container
+  const athSource = athContainer || list;
+  athSource.querySelectorAll('.ath-card-link').forEach(link => {
     link.addEventListener('click', () => {
       const slug = link.dataset.bundleSlug;
       const bundle = bundles.find(item => item.slug === slug);


### PR DESCRIPTION
Closes #24

## Summary
- Direct navigation to `/around-the-horn/` now shows a friendly recovery message instead of a dead end
- ATH bundle cards render above the feed toolbar so they're visible without scrolling past filters
- Removed the duplicate inline `relativeDate()` from the ATH page; imports from `utils.js`

## Files changed
- `src/pages/around-the-horn/index.astro` — dead-end fallback UI, removed duplicate `relativeDate`
- `src/pages/index.astro` — ATH container moved above feed toolbar
- `src/scripts/feeds.js` — ATH cards render into dedicated `#athBundleContainer`
- `public/style.css` — `.ath-dead-end` styles

## Test plan
- [ ] Open `/around-the-horn/` in a fresh tab — see "Story bundle unavailable" with orange back link
- [ ] Click an ATH card on homepage — bundle opens correctly
- [ ] ATH bundle section appears above the feed toolbar on homepage
- [ ] No JS errors from duplicate function definition

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1vhzbYUCRYNikqatrcAYN)_