### PR TITLE
Batch 4: Housekeeping — audio path, overnight refresh, CC theme, reader modal

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3259,7 +3259,7 @@ a.il-name:hover { color: var(--orange); }
 
 .reader-modal {
   width: min(800px, 100%);
-  background: #fff;
+  background: var(--surface);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -3270,8 +3270,8 @@ a.il-name:hover { color: var(--orange); }
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  background: #f5f5f5;
-  border-bottom: 1px solid #e0e0e0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
   gap: 12px;
   flex-shrink: 0;
 }
@@ -3284,7 +3284,7 @@ a.il-name:hover { color: var(--orange); }
   color: #fff;
   flex-shrink: 0;
 }
-.reader-date { font-size: 0.73rem; color: #777; }
+.reader-date { font-size: 0.73rem; color: var(--text-3); }
 .reader-actions { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 .btn-original-reader {
   font-size: 0.78rem;
@@ -3299,21 +3299,21 @@ a.il-name:hover { color: var(--orange); }
 .btn-close-reader {
   padding: 5px 9px;
   background: transparent;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border);
   border-radius: 5px;
-  color: #666;
+  color: var(--text-2);
   font-size: 1rem;
   transition: all 0.15s;
 }
-.btn-close-reader:hover { background: #eee; color: #333; }
+.btn-close-reader:hover { background: var(--border-light); color: var(--text); }
 
 .reader-title {
   padding: 16px 20px 14px;
   font-size: 1.2rem;
   font-weight: 700;
   line-height: 1.4;
-  color: #111;
-  border-bottom: 1px solid #eee;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
 .reader-body { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
@@ -3328,7 +3328,7 @@ a.il-name:hover { color: var(--orange); }
   overflow-y: auto;
 }
 .reader-fallback.hidden { display: none; }
-.reader-excerpt { font-size: 1rem; line-height: 1.75; color: #333; }
+.reader-excerpt { font-size: 1rem; line-height: 1.75; color: var(--text-2); }
 .btn-read-full {
   align-self: flex-start;
   padding: 11px 22px;

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -250,9 +250,13 @@ function setupEvents() {
   });
 
   // Auto-refresh scores and transactions every 5 minutes
+  // Skip fetches during off-hours (midnight through 8am local time)
   setInterval(() => {
-    loadScores();
-    loadTransactions();
+    const hour = new Date().getHours();
+    if (hour >= 9) {
+      loadScores();
+      loadTransactions();
+    }
   }, 5 * 60 * 1000);
 
   // ── Easter Eggs ──────────────────────────────────────────────────

--- a/src/scripts/easter-eggs.js
+++ b/src/scripts/easter-eggs.js
@@ -2,12 +2,14 @@
 import { applyTheme } from './theme.js';
 import { loadPrefs } from './storage.js';
 
+const BASE = '/yardreport';
+
 export function triggerOriolesMagic() {
   const container = document.createElement('div');
   container.className = 'magic-confetti';
   document.body.appendChild(container);
 
-  const audio = new Audio('/yardreport/audio/orioles_magic_short.mp3');
+  const audio = new Audio(`${BASE}/audio/orioles_magic_short.mp3`);
   audio.volume = 0.7;
   let confettiInterval = null;
   let confettiKickoff = null;

--- a/src/scripts/theme.js
+++ b/src/scripts/theme.js
@@ -10,10 +10,12 @@ export function applyTheme(theme) {
 }
 
 // Apply saved theme immediately on import
-const _savedTheme = loadPrefs().theme || 'dark';
+const _prefs = loadPrefs();
+const _savedTheme = _prefs.theme || 'dark';
 applyTheme(_savedTheme);
 
-// Auto City Connect on Fridays (without overwriting the user's saved preference)
-if (new Date().getDay() === 5 && _savedTheme !== 'city-connect') {
+// Auto City Connect on Fridays — only if the user has NOT set an explicit preference
+// (i.e. loadPrefs().theme is undefined/null, meaning they are on the default)
+if (new Date().getDay() === 5 && !_prefs.theme) {
   document.documentElement.setAttribute('data-theme', 'city-connect');
 }


### PR DESCRIPTION
Closes #25

## Summary
Four small targeted fixes from the site review:
- Audio path in `easter-eggs.js` uses a `BASE` constant instead of a hardcoded absolute path
- Auto-refresh skips API calls between midnight and 9am
- City Connect Friday auto-theme only applies when the user has no stored preference
- Reader modal styles use CSS variables so they respect dark/light/CC themes

## Files changed
- `src/scripts/easter-eggs.js` — `BASE` constant for audio path
- `src/scripts/app.js` — `getHours() < 9` guard on refresh interval
- `src/scripts/theme.js` — CC Friday only when `!prefs.theme`
- `public/style.css` — reader modal uses `var(--surface)`, `var(--text)`, `var(--border)`

## Test plan
- [ ] Orioles Magic audio plays (if you can trigger the easter egg)
- [ ] Verify no API calls fire between midnight–9am (check Network tab on a timer tick)
- [ ] Set theme to Dark, wait for Friday (or mock date) — Dark theme should hold, not switch to CC
- [ ] Open reader modal in dark mode — panel should be dark, not a white flash

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1vhzbYUCRYNikqatrcAYN)_