### PR TITLE
Batch 5: MLB API abstraction layer and single-pass box score render

### DIFF
--- a/src/scripts/mlbApi.js
+++ b/src/scripts/mlbApi.js
@@ -1,0 +1,84 @@
+// ── MLB Stats API abstraction layer ───────────────────────────────
+// All direct MLB API fetch() calls go here. Each function owns URL
+// construction and returns parsed JSON (or a relevant sub-object).
+// Throws on non-OK responses so callers can catch network errors.
+
+import { MLB, ORIOLES_ID, SEASON } from './config.js';
+
+async function getJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`MLB API ${res.status}: ${url}`);
+  return res.json();
+}
+
+// ── Schedule ──────────────────────────────────────────────────────
+// hydrate: comma-separated hydration string, e.g. 'linescore,team,venue,decisions,probablePitcher'
+export async function fetchScheduleByDate(date, { hydrate = 'linescore,team,venue,decisions,probablePitcher' } = {}) {
+  return getJson(`${MLB}/schedule?sportId=1&date=${date}&hydrate=${encodeURIComponent(hydrate)}`);
+}
+
+// Fetch Orioles schedule over a date range (used by On Deck sidebar)
+export async function fetchTeamSchedule(teamId = ORIOLES_ID, startDate, endDate, { hydrate = 'probablePitcher,venue' } = {}) {
+  return getJson(`${MLB}/schedule?sportId=1&teamId=${teamId}&startDate=${startDate}&endDate=${endDate}&hydrate=${encodeURIComponent(hydrate)}`);
+}
+
+// Fetch Orioles schedule with media content hydration (used by recap video)
+export async function fetchTeamScheduleWithMedia(teamId = ORIOLES_ID, startDate, endDate) {
+  return getJson(`${MLB}/schedule?sportId=1&teamId=${teamId}&startDate=${startDate}&endDate=${endDate}&hydrate=${encodeURIComponent('game(content(media(epg)))')}`);
+}
+
+// ── Box score ─────────────────────────────────────────────────────
+export async function fetchBoxscore(gamePk) {
+  return getJson(`${MLB}/game/${gamePk}/boxscore`);
+}
+
+// ── Pitch arsenal ─────────────────────────────────────────────────
+export async function fetchArsenal(playerId) {
+  return getJson(`${MLB}/people/${playerId}/stats?stats=pitchArsenal&season=${SEASON}&group=pitching`);
+}
+
+// ── Team stats (season hitting) ───────────────────────────────────
+export async function fetchTeamStats(teamId) {
+  const data = await getJson(`${MLB}/teams/${teamId}/stats?stats=season&season=${SEASON}&group=hitting`);
+  return data.stats?.[0]?.splits?.[0]?.stat ?? null;
+}
+
+// ── Pitcher vs opposing team (career) ─────────────────────────────
+export async function fetchPitcherVsTeam(pitcherId, opposingTeamId) {
+  const data = await getJson(
+    `${MLB}/people/${pitcherId}/stats?stats=vsTeamTotal&group=pitching&opposingTeamId=${opposingTeamId}`
+  );
+  return data.stats?.[0]?.splits?.[0]?.stat ?? null;
+}
+
+// ── Standings ─────────────────────────────────────────────────────
+export async function fetchStandings() {
+  return getJson(`${MLB}/standings?leagueId=103,104&season=${SEASON}&standingsTypes=regularSeason`);
+}
+
+// ── Roster ────────────────────────────────────────────────────────
+export async function fetchRoster(teamId = ORIOLES_ID, { rosterType = '40Man', season = SEASON } = {}) {
+  return getJson(`${MLB}/teams/${teamId}/roster?rosterType=${rosterType}&season=${season}`);
+}
+
+// Roster without season param (used by loadInjuryReport)
+export async function fetchRosterCurrent(teamId = ORIOLES_ID, { rosterType = '40Man' } = {}) {
+  return getJson(`${MLB}/teams/${teamId}/roster?rosterType=${rosterType}`);
+}
+
+// ── Transactions ──────────────────────────────────────────────────
+export async function fetchTransactions(teamId = ORIOLES_ID, startDate, endDate) {
+  return getJson(`${MLB}/transactions?teamId=${teamId}&startDate=${startDate}&endDate=${endDate}`);
+}
+
+// ── Stat leaders ──────────────────────────────────────────────────
+// Team leaders (e.g. Orioles)
+export async function fetchTeamLeaders(teamId = ORIOLES_ID, { leaderCategories, season = SEASON, leaderGameTypes = 'R', playerPool = 'Qualified' } = {}) {
+  return getJson(`${MLB}/teams/${teamId}/leaders?leaderCategories=${leaderCategories}&season=${season}&leaderGameTypes=${leaderGameTypes}&playerPool=${playerPool}`);
+}
+
+// League leaders (AL, NL, or MLB)
+export async function fetchLeagueLeaders({ leaderCategories, season = SEASON, leaderGameTypes = 'R', leagueId = '', playerPool = 'Qualified', limit = 1 } = {}) {
+  const leagueParam = leagueId ? `&leagueId=${leagueId}` : '';
+  return getJson(`${MLB}/stats/leaders?leaderCategories=${leaderCategories}&season=${season}&leaderGameTypes=${leaderGameTypes}${leagueParam}&playerPool=${playerPool}&limit=${limit}`);
+}

--- a/src/scripts/scores.js
+++ b/src/scripts/scores.js
@@ -1,13 +1,18 @@
 // ── Scores, box score popover, lineup, scout notes, arsenal ───────
 import {
-  MLB,
   ORIOLES_ID,
   PITCH_NAMES,
   PROXY,
-  SEASON,
   TEAM_ABBREV,
   TEAM_SLUG,
 } from './config.js';
+import {
+  fetchScheduleByDate,
+  fetchBoxscore as apiFetchBoxscore,
+  fetchArsenal as apiFetchArsenal,
+  fetchTeamStats as apiFetchTeamStats,
+  fetchPitcherVsTeam as apiFetchPitcherVsTeam,
+} from './mlbApi.js';
 import { $, esc, localDateStr, dayLabel, formatGameTime, teamLogoSrc } from './utils.js';
 import { ensureWalkupSongsLoaded, getWalkupSongUrls } from './walkup-songs.js';
 import { triggerOriolesMagic } from './easter-eggs.js';
@@ -189,7 +194,7 @@ function maybeTriggerOriolesWinMagic(games) {
 export async function fetchBoxscore(gamePk) {
   if (boxscoreCache[gamePk]) return boxscoreCache[gamePk];
   try {
-    const data = await fetch(`${MLB}/game/${gamePk}/boxscore`).then(r => r.json());
+    const data = await apiFetchBoxscore(gamePk);
     boxscoreCache[gamePk] = data;
     return data;
   } catch { return null; }
@@ -199,9 +204,7 @@ export async function fetchArsenal(playerId) {
   if (!playerId) return null;
   if (arsenalCache[playerId]) return arsenalCache[playerId];
   try {
-    const data = await fetch(
-      `${MLB}/people/${playerId}/stats?stats=pitchArsenal&season=${SEASON}&group=pitching`
-    ).then(r => r.json());
+    const data = await apiFetchArsenal(playerId);
     arsenalCache[playerId] = data;
     return data;
   } catch { return null; }
@@ -211,10 +214,7 @@ export async function fetchTeamStats(teamId) {
   if (!teamId) return null;
   if (teamStatsCache[teamId]) return teamStatsCache[teamId];
   try {
-    const data = await fetch(
-      `${MLB}/teams/${teamId}/stats?stats=season&season=${SEASON}&group=hitting`
-    ).then(r => r.json());
-    const result = data.stats?.[0]?.splits?.[0]?.stat ?? null;
+    const result = await apiFetchTeamStats(teamId);
     teamStatsCache[teamId] = result;
     return result;
   } catch { return null; }
@@ -225,10 +225,7 @@ export async function fetchPitcherVsTeam(pitcherId, oppTeamId) {
   const key = `${pitcherId}_vs_${oppTeamId}`;
   if (pitcherVsCache[key] !== undefined) return pitcherVsCache[key];
   try {
-    const data = await fetch(
-      `${MLB}/people/${pitcherId}/stats?stats=vsTeamTotal&group=pitching&opposingTeamId=${oppTeamId}`
-    ).then(r => r.json());
-    const result = data.stats?.[0]?.splits?.[0]?.stat ?? null;
+    const result = await apiFetchPitcherVsTeam(pitcherId, oppTeamId);
     pitcherVsCache[key] = result;
     return result;
   } catch { return null; }
@@ -1146,9 +1143,9 @@ export async function loadScores() {
     const tomorrow = localDateStr(1);
 
     const [ydData, todayData, tmData] = await Promise.all([
-      fetch(`${MLB}/schedule?sportId=1&date=${yesterday}&hydrate=linescore,team,venue,decisions,probablePitcher`).then(r => r.json()),
-      fetch(`${MLB}/schedule?sportId=1&date=${today}&hydrate=linescore,team,venue,decisions,probablePitcher`).then(r => r.json()),
-      fetch(`${MLB}/schedule?sportId=1&date=${tomorrow}&hydrate=linescore,team,venue,decisions,probablePitcher`).then(r => r.json()),
+      fetchScheduleByDate(yesterday),
+      fetchScheduleByDate(today),
+      fetchScheduleByDate(tomorrow),
     ]);
 
     const allGames = [
@@ -1226,7 +1223,7 @@ export async function loadScores() {
       pinnedChip = null; setChipExpandedState(null);
       boxPopover.classList.add('hidden');
     }
-    function showBoxScore(chip) {
+    async function showBoxScore(chip) {
       const pk = chip.dataset.gamepk;
       const g = state.gamesMap[pk];
       if (!g) return;
@@ -1263,34 +1260,39 @@ export async function loadScores() {
         };
       }
 
+      // Build the list of fetches that still need to complete before rendering.
+      const pending = [
+        !boxscoreCache[pk]                                                              && fetchBoxscore(pk),
+        isOriolesGame                                                                   && ensureWalkupSongsLoaded(PROXY),
+        isPreview && !arsenalCache[awayPitcherId]                                      && fetchArsenal(awayPitcherId),
+        isPreview && !arsenalCache[homePitcherId]                                      && fetchArsenal(homePitcherId),
+        isLive && livePitcherId && !arsenalCache[livePitcherId]                        && fetchArsenal(livePitcherId),
+        isPreview && isOriolesGame && pitcherVsCache[awayVsKey] === undefined          && fetchPitcherVsTeam(awayPitcherId, homeTeamId),
+        isPreview && isOriolesGame && pitcherVsCache[homeVsKey] === undefined          && fetchPitcherVsTeam(homePitcherId, awayTeamId),
+        isPreview && isOriolesGame && !teamStatsCache[awayTeamId]                      && fetchTeamStats(awayTeamId),
+        isPreview && isOriolesGame && !teamStatsCache[homeTeamId]                      && fetchTeamStats(homeTeamId),
+      ].filter(Boolean);
+
+      if (pending.length) {
+        // Show a loading skeleton while all data is in flight, then render once.
+        boxPopover.innerHTML = '<div class="box-score-loading">Loading…</div>';
+        boxPopover.style.left = '-9999px'; boxPopover.style.top = '0';
+        boxPopover.classList.remove('hidden');
+        positionPopover(chip);
+
+        await Promise.allSettled(pending);
+
+        // If the user dismissed the popover while we were loading, bail out.
+        if (boxPopover.classList.contains('hidden')) return;
+      }
+
+      // All data is now in the caches — single render with complete data.
       boxPopover.innerHTML = renderBoxScore(g, boxscoreCache[pk] || null, buildArsenals(), buildMatchupCtx());
       boxPopover.style.left = '-9999px'; boxPopover.style.top = '0';
       boxPopover.classList.remove('hidden');
       syncPopoverTeamDetailHeights(boxPopover);
       initScrollIndicators(boxPopover);
       positionPopover(chip);
-
-      const missing = [
-        !boxscoreCache[pk]                                         && fetchBoxscore(pk),
-        isOriolesGame                                              && ensureWalkupSongsLoaded(PROXY),
-        isPreview && !arsenalCache[awayPitcherId]                 && fetchArsenal(awayPitcherId),
-        isPreview && !arsenalCache[homePitcherId]                 && fetchArsenal(homePitcherId),
-        isLive && livePitcherId && !arsenalCache[livePitcherId]   && fetchArsenal(livePitcherId),
-        isPreview && isOriolesGame && pitcherVsCache[awayVsKey] === undefined && fetchPitcherVsTeam(awayPitcherId, homeTeamId),
-        isPreview && isOriolesGame && pitcherVsCache[homeVsKey] === undefined && fetchPitcherVsTeam(homePitcherId, awayTeamId),
-        isPreview && isOriolesGame && !teamStatsCache[awayTeamId] && fetchTeamStats(awayTeamId),
-        isPreview && isOriolesGame && !teamStatsCache[homeTeamId] && fetchTeamStats(homeTeamId),
-      ].filter(Boolean);
-
-      if (missing.length) {
-        Promise.all(missing).then(() => {
-          if (boxPopover.classList.contains('hidden')) return;
-          boxPopover.innerHTML = renderBoxScore(g, boxscoreCache[pk] || null, buildArsenals(), buildMatchupCtx());
-          syncPopoverTeamDetailHeights(boxPopover);
-          initScrollIndicators(boxPopover);
-          positionPopover(chip);
-        });
-      }
     }
     function scheduleShowBoxScore(chip) {
       if (pinnedChip) return;

--- a/src/scripts/sidebars.js
+++ b/src/scripts/sidebars.js
@@ -1,7 +1,6 @@
 // ── Sidebars ──────────────────────────────────────────────────────
 import {
   DIVISION_NAMES,
-  MLB,
   ORIOLES_ID,
   PROXY,
   SEASON,
@@ -9,6 +8,16 @@ import {
   TEAM_PAGE,
   TEAM_SLUG,
 } from './config.js';
+import {
+  fetchTeamSchedule,
+  fetchTeamScheduleWithMedia,
+  fetchStandings,
+  fetchRoster,
+  fetchRosterCurrent,
+  fetchTransactions,
+  fetchTeamLeaders,
+  fetchLeagueLeaders,
+} from './mlbApi.js';
 import { state } from './state.js';
 import {
   $,
@@ -27,9 +36,7 @@ import { WALKUP_ICON_SVG } from './scores.js';
 // ── Standings ─────────────────────────────────────────────────────
 export async function loadStandings() {
   try {
-    const data = await fetch(
-      `${MLB}/standings?leagueId=103,104&season=${SEASON}&standingsTypes=regularSeason`
-    ).then(r => r.json());
+    const data = await fetchStandings();
 
     state.standings = data.records.map(div => ({
       divisionId: div.division.id,
@@ -99,9 +106,7 @@ export async function loadOnDeck() {
     const today = localDateStr(0);
     const tomorrowStr = localDateStr(1);
     const endDate = localDateStr(14);
-    const data = await fetch(
-      `${MLB}/schedule?sportId=1&teamId=${ORIOLES_ID}&startDate=${today}&endDate=${endDate}&hydrate=probablePitcher,venue`
-    ).then(r => r.json());
+    const data = await fetchTeamSchedule(ORIOLES_ID, today, endDate);
 
     const games = (data.dates ?? []).flatMap(d => d.games);
     const todayStr = today;
@@ -240,7 +245,7 @@ export async function loadRoster() {
     // song fetch resolves if it was still in flight.
     const songPromise = ensureWalkupSongsLoaded(PROXY);
     const [data] = await Promise.all([
-      fetch(`${MLB}/teams/${ORIOLES_ID}/roster?rosterType=40Man&season=${SEASON}`).then(r => r.json()),
+      fetchRoster(ORIOLES_ID),
     ]);
 
     const all = data.roster ?? [];
@@ -333,9 +338,7 @@ export async function loadTransactions() {
     startD.setDate(startD.getDate() - 14);
     const start = startD.toISOString().slice(0, 10);
 
-    const data = await fetch(
-      `${MLB}/transactions?teamId=${ORIOLES_ID}&startDate=${start}&endDate=${end}`
-    ).then(r => r.json());
+    const data = await fetchTransactions(ORIOLES_ID, start, end);
 
     const txns = (data.transactions ?? [])
       .sort((a, b) => new Date(b.date || b.effectiveDate) - new Date(a.date || a.effectiveDate))
@@ -373,8 +376,8 @@ export async function loadInjuryReport() {
   const wrap = $('ilWrap');
   try {
     const [data, txData] = await Promise.all([
-      fetch(`${MLB}/teams/${ORIOLES_ID}/roster?rosterType=40Man`).then(r => r.json()),
-      fetch(`${MLB}/transactions?teamId=${ORIOLES_ID}&startDate=${SEASON}-01-01&endDate=${localDateStr(0)}`).then(r => r.json()).catch(() => ({ transactions: [] })),
+      fetchRosterCurrent(ORIOLES_ID),
+      fetchTransactions(ORIOLES_ID, `${SEASON}-01-01`, localDateStr(0)).catch(() => ({ transactions: [] })),
     ]);
 
     const injured = (data.roster ?? []).filter(p =>
@@ -535,7 +538,7 @@ async function fetchOriolesRecapVideo() {
 
   const [playlistData, gameData] = await Promise.all([
     fetch(`${PROXY}?url=${encodeURIComponent(`https://www.youtube.com/feeds/videos.xml?playlist_id=${ORIOLES_RECAP_PLAYLIST}`)}`).then(r => r.json()),
-    fetch(`${MLB}/schedule?sportId=1&teamId=${ORIOLES_ID}&startDate=${startDate}&endDate=${endDate}&hydrate=game(content(media(epg)))`).then(r => r.json()),
+    fetchTeamScheduleWithMedia(ORIOLES_ID, startDate, endDate),
   ]);
 
   const recapItems = playlistData.items ?? [];
@@ -848,12 +851,10 @@ const ROY_CATS = 'onBasePlusSlugging,homeRuns,battingAverage,earnedRunAverage,st
 const ROY_BATTING_ORDER  = ['onBasePlusSlugging', 'homeRuns', 'battingAverage'];
 const ROY_PITCHING_ORDER = ['earnedRunAverage', 'strikeouts', 'walksAndHitsPerInningPitched'];
 
-function leadersFetchUrl(scope) {
-  if (scope === 'orioles') {
-    return `${MLB}/teams/${ORIOLES_ID}/leaders?leaderCategories=${TEAM_LEADERS_CATS}&season=${SEASON}&leaderGameTypes=R&playerPool=Qualified`;
-  }
-  const leagueParam = scope === 'al' ? '&leagueId=103' : scope === 'nl' ? '&leagueId=104' : '';
-  return `${MLB}/stats/leaders?leaderCategories=${LEAGUE_LEADERS_CATS}&season=${SEASON}&leaderGameTypes=R${leagueParam}&playerPool=Qualified&limit=1`;
+function leagueIdForScope(scope) {
+  if (scope === 'al') return 103;
+  if (scope === 'nl') return 104;
+  return '';
 }
 
 function parseLeadersData(categories, battingOrder = BATTING_ORDER, pitchingOrder = PITCHING_ORDER) {
@@ -876,8 +877,8 @@ export async function loadLeaders() {
     if (leadersScope === 'roy') {
       if (!leadersCache.roy) {
         const [alData, nlData] = await Promise.all([
-          fetch(`${MLB}/stats/leaders?leaderCategories=${ROY_CATS}&season=${SEASON}&leaderGameTypes=R&leagueId=103&playerPool=Rookies&limit=1`).then(r => r.json()),
-          fetch(`${MLB}/stats/leaders?leaderCategories=${ROY_CATS}&season=${SEASON}&leaderGameTypes=R&leagueId=104&playerPool=Rookies&limit=1`).then(r => r.json()),
+          fetchLeagueLeaders({ leaderCategories: ROY_CATS, leagueId: 103, playerPool: 'Rookies' }),
+          fetchLeagueLeaders({ leaderCategories: ROY_CATS, leagueId: 104, playerPool: 'Rookies' }),
         ]);
         leadersCache.roy = {
           al: parseLeadersData(alData.leagueLeaders ?? [], ROY_BATTING_ORDER, ROY_PITCHING_ORDER),
@@ -887,9 +888,13 @@ export async function loadLeaders() {
       renderLeaders();
       return;
     }
-    const url = leadersFetchUrl(leadersScope);
     if (!leadersCache[leadersScope]) {
-      const data = await fetch(url).then(r => r.json());
+      let data;
+      if (leadersScope === 'orioles') {
+        data = await fetchTeamLeaders(ORIOLES_ID, { leaderCategories: TEAM_LEADERS_CATS });
+      } else {
+        data = await fetchLeagueLeaders({ leaderCategories: LEAGUE_LEADERS_CATS, leagueId: leagueIdForScope(leadersScope) });
+      }
       const categories = leadersScope === 'orioles' ? (data.teamLeaders ?? []) : (data.leagueLeaders ?? []);
       leadersCache[leadersScope] = parseLeadersData(categories);
     }
@@ -976,9 +981,7 @@ export async function loadDepthChart() {
   const wrap = $('depthChartWrap');
   if (!wrap) return;
   try {
-    const data = await fetch(
-      `${MLB}/teams/${ORIOLES_ID}/roster?rosterType=depthChart&season=${SEASON}`
-    ).then(r => r.json());
+    const data = await fetchRoster(ORIOLES_ID, { rosterType: 'depthChart' });
 
     const players = data.roster ?? [];
     if (!players.length) {


### PR DESCRIPTION
Closes #26

## Summary
- New `src/scripts/mlbApi.js` centralizes all MLB Stats API URL construction and fetching in named async functions
- `scores.js` and `sidebars.js` refactored to import from `mlbApi.js` — no more inline URL strings
- Box score popover now shows a loading skeleton, awaits all async fetches via `Promise.allSettled`, then renders exactly once — eliminating the visible re-render flash

## Files changed
- `src/scripts/mlbApi.js` — new file, 10+ named API functions
- `src/scripts/scores.js` — imports from `mlbApi.js`, `showBoxScore()` made async with single-pass render
- `src/scripts/sidebars.js` — imports from `mlbApi.js`, direct fetch calls removed

## Test plan
- [ ] Scores bar loads and displays games correctly
- [ ] Click a score chip — box score opens with a brief "Loading…" state then renders complete (no flash)
- [ ] Roster, transactions, IL, standings, leaders all load normally
- [ ] On Deck shows next Orioles game
- [ ] No broken fetch calls in Network tab (all URLs should match previous behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1vhzbYUCRYNikqatrcAYN)_